### PR TITLE
Add text function to create textual representation of render

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -7,6 +7,7 @@ function shallowRender(elementOrFunction, context) {
   context = context || {};
   global.document = global.document || { body: {} };
   ReactContext.current = context;
+
   var shallowRenderer = TestUtils.createRenderer();
   var element = TestUtils.isElement(elementOrFunction) ?
     elementOrFunction : elementOrFunction();
@@ -17,6 +18,9 @@ function shallowRender(elementOrFunction, context) {
     textIn: function(query) {
       var node = findNodeIn(shallowRenderer, query);
       return node && node.props && String(node.props.children);
+    },
+    text: function() {
+      return getTextFromNodes(shallowRenderer.getRenderOutput());
     },
     fillField: function(query, value) {
       var node = findNodeIn(shallowRenderer, query);
@@ -85,6 +89,20 @@ function findNode(node, fn) {
     return findNode(node.props.children, fn);
   }
   return false;
+}
+
+function getTextFromNodes(nodes) {
+  if (typeof nodes.type === 'function') {
+    return '<' + nodes.type.displayName + ' />';
+  }
+  if (typeof nodes === 'string') return nodes;
+  if (typeof nodes.map === 'function') {
+    return nodes.map(getTextFromNodes).join(' ');
+  }
+
+  var children = nodes.props && nodes.props.children;
+  if (!children) return '';
+  return getTextFromNodes(children);
 }
 
 exports.chaiShallowRender = function(chai, utils) {

--- a/test/test.js
+++ b/test/test.js
@@ -165,4 +165,19 @@ describe("skin-deep", function() {
     });
   });
 
+  describe("text", function() {
+    it("should out a textual representation of the tree", function() {
+      var tree = sd.shallowRender($('h1', { title: "blah" }, [
+        "Heading!", $('div', { title: "blah" }, [
+          React.createClass({
+            displayName: 'Widget',
+            render: function() { return 'Should not see'; }
+          }),
+          'Some text.',
+          'More text.'
+        ])
+      ]));
+      expect(tree.text()).to.eql('Heading! <Widget /> Some text. More text.');
+    });
+  });
 });


### PR DESCRIPTION
Need to add tests but wanted to check that this is a useful feature. It shallow renders an element to string. It renders sub components like this : ```<Tappable Price />```