### PR TITLE
Fix not looking in array nodes

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -74,21 +74,18 @@ function findNode(node, fn) {
   if (fn(node)) {
     return node;
   }
-  if (!node.props || !node.props.children) {
-    return false;
-  }
-  if (typeof node.props.children.some === 'function') {
+  if (node.some) {
     var matched = false;
-    node.props.children.some(function(n) {
+    node.some(function(n) {
       matched = findNode(n, fn);
       return matched;
     });
     return matched;
   }
-  if (typeof node.props.children === 'object') {
-    return findNode(node.props.children, fn);
+  if (!node.props || !node.props.children) {
+    return false;
   }
-  return false;
+  return findNode(node.props.children, fn);
 }
 
 function getTextFromNodes(nodes) {

--- a/test/test.js
+++ b/test/test.js
@@ -74,9 +74,14 @@ describe("skin-deep", function() {
   describe("findNode", function() {
     var tree = sd.shallowRender(
       $('div', {},
-        $('div', {className: "abc"}, "ABC"),
+        $('div', {}, 'objection!'),
         $('div', {id: "def"}, "DEF"),
-        $('object', {}, "objection!")
+        $('div', {}, [
+          $('div', {}, "objection!"),
+          $('object', {}, "objection!"),
+          'hello',
+          [$('div', {className: "abc"}, "ABC")]
+        ])
       )
     );
 


### PR DESCRIPTION
Previously findNode did not look into array nodes. I added a test case that causes the previous incarnation to fail and then fixed it.