### PR TITLE
Added falsey check of node var

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -107,6 +107,7 @@ function findNodeById(id) {
 }
 
 function findNode(node, fn) {
+  if (!node) return false;
   if (fn(node)) {
     return node;
   }


### PR DESCRIPTION
Inline conditionals like below that return null can trip up some of the `node` var checks:

```js
{foo && <Component />}
```

I've added an early return to `findNode()` because it seems to be the common function among them all.