### PR TITLE
Expose api

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.14",
     "mocha": "^2.2.5",
-    "react": "^0.13.3"
+    "react": "^0.14.0-beta3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "homepage": "https://github.com/glenjamin/skin-deep",
   "dependencies": {
-    "is-subset": "^0.1.1"
+    "is-subset": "^0.1.1",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.14",
     "mocha": "^2.2.5",
-    "react": "^0.14.0-beta3"
+    "react": "^0.13.3"
   }
 }

--- a/skin-deep.js
+++ b/skin-deep.js
@@ -1,14 +1,16 @@
 var subset = require('is-subset');
 
 var React = require('react');
-var React013 = (React.version.substring(0, 4) == '0.13');
+var React013 = (React.version.substring(0, 4) === '0.13');
 
 var TestUtils;
-if (React013) {
-  TestUtils = require('react/addons').addons.TestUtils;
-} else {
-  TestUtils = require('react-addons-test-utils');
-}
+//if (React013) {
+//  TestUtils = require('react/addons').addons.TestUtils;
+//} else {
+//  TestUtils = require('react-addons-test-utils');
+//}
+TestUtils = require('react/addons').addons.TestUtils;
+
 
 function renderToStaticMarkup(element) {
   if (React013) {
@@ -106,6 +108,35 @@ function SkinDeep(getCurrentNode, instance) {
           subset(node.props, props) &&
           subset(props, node.props);
       });
+    },
+    findComponentWithoutChildren: function(type, props) {
+      return this.findComponentsWithoutChildren[0] || false;
+    },
+    findComponentsWithoutChildren: function(type, props) {
+      if (arguments.length == 1) {
+        console.warn(
+          "Using a component in findComponent is deprecated. " +
+          "Pass name and props as separate arguments instead"
+        );
+        var search = type;
+        type = getComponentName(search.type) || search.type;
+        props = search.props;
+      }
+      return findNodes(getCurrentNode(), function(node) {
+        if (node && node.props && node.props.children) {
+          var props1 = clone(node.props);
+          var props2 = clone(props);
+          delete props1['children'];
+
+          return matchComponentType(type, node) &&
+            subset(props1, props2) &&
+            subset(props2, props1);
+        } else{
+          return matchComponentType(type, node) &&
+            subset(node.props, props) &&
+            subset(props, node.props);
+        }
+      }, false);
     },
     findComponentLike: function(type, props) {
       if (arguments.length == 1) {
@@ -255,3 +286,13 @@ function mapcat(array, fn) {
   });
   return result;
 }
+
+function clone(obj) {
+  if (null == obj || "object" != typeof obj) return obj;
+  var copy = obj.constructor();
+  for (var attr in obj) {
+    if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
+  }
+  return copy;
+}
+

--- a/skin-deep.js
+++ b/skin-deep.js
@@ -2,7 +2,6 @@ var subset = require('is-subset');
 
 var React = require('react');
 var versionNumber = Number(React.version.substring(0, 4));
-console.log('version number ...............', versionNumber);
 var TestUtils;
 if (versionNumber >= 0.13) {
  TestUtils = require('react/addons').addons.TestUtils;
@@ -153,6 +152,7 @@ function SkinDeep(getCurrentNode, instance) {
       }
       return findNodes(getCurrentNode(), function(node) {
         if (node && node.props && props) {
+
           var props1 = clone(node.props);
           var props2 = clone(props);
           delete props1['children'];

--- a/skin-deep.js
+++ b/skin-deep.js
@@ -1,5 +1,5 @@
 var subset = require('is-subset');
-
+var objectAssign = require('object-assign');
 var React = require('react');
 var versionNumber = Number(React.version.substring(0, 4));
 var TestUtils;
@@ -129,17 +129,10 @@ function SkinDeep(getCurrentNode, instance) {
     },
     findComponentWithoutChildren: function(type, props) {
       if (arguments.length === 1) {
-        console.warn(
-          "Using a component in findComponent is deprecated. " +
-          "Pass name and props as separate arguments instead"
-        );
-        var search = type;
-        type = getComponentName(search.type) || search.type;
-        props = search.props;
+        return this.findComponentsWithoutChildren(type)[0] || false;
       }
-      return this.findComponentsWithoutChildren(type,props)[0] || false;
+      return this.findComponentsWithoutChildren(type, props)[0] || false;
     },
-
     findComponentsWithoutChildren: function(type, props) {
       if (arguments.length === 1) {
         console.warn(
@@ -151,21 +144,9 @@ function SkinDeep(getCurrentNode, instance) {
         props = search.props;
       }
       return findNodes(getCurrentNode(), function(node) {
-        if (node && node.props && props) {
-
-          var props1 = clone(node.props);
-          var props2 = clone(props);
-          delete props1['children'];
-          delete props2['children'];
-
           return matchComponentType(type, node) &&
-            subset(props1, props2) &&
-            subset(props2, props1);
-        } else{
-          return matchComponentType(type, node) &&
-            subset(node.props, props) &&
-            subset(props, node.props);
-        }
+            subset(objectAssign({}, node.props, {children: ''}), objectAssign({}, props, {children: ''})) &&
+            subset(objectAssign({}, props, {children: ''}), objectAssign({}, node.props, {children: ''}));
       }, false);
     },
     getRenderOutput: function() {

--- a/skin-deep.js
+++ b/skin-deep.js
@@ -1,16 +1,18 @@
 var subset = require('is-subset');
 var objectAssign = require('object-assign');
+
 var React = require('react');
-var versionNumber = Number(React.version.substring(0, 4));
+var React013 = (React.version.substring(0, 4) == '0.13');
+
 var TestUtils;
-if (versionNumber >= 0.13) {
- TestUtils = require('react/addons').addons.TestUtils;
+if (React013) {
+  TestUtils = require('react/addons').addons.TestUtils;
 } else {
- TestUtils = require('react-addons-test-utils');
+  TestUtils = require('react-addons-test-utils');
 }
 
 function renderToStaticMarkup(element) {
-  if (versionNumber >= 0.13) {
+  if (React013) {
     return React.renderToStaticMarkup(element);
   }
 
@@ -18,14 +20,9 @@ function renderToStaticMarkup(element) {
 }
 
 function withContext(context, fn) {
-  if (versionNumber < 0.13) return fn();
+  if (!React013) return fn();
 
-  var ReactContext;
-  if (versionNumber === 0.13) {
-    ReactContext = require('react/lib/ReactContext');
-  } else {
-    ReactContext = require('react');
-  }
+  var ReactContext = require('react/lib/ReactContext');
   ReactContext.current = context;
   var result = fn();
   ReactContext.current = {};
@@ -96,7 +93,7 @@ function SkinDeep(getCurrentNode, instance) {
       }
     },
     findComponent: function(type, props) {
-      if (arguments.length === 1) {
+      if (arguments.length == 1) {
         console.warn(
           "Using a component in findComponent is deprecated. " +
           "Pass name and props as separate arguments instead"
@@ -112,7 +109,7 @@ function SkinDeep(getCurrentNode, instance) {
       });
     },
     findComponentLike: function(type, props) {
-      if (arguments.length === 1) {
+      if (arguments.length == 1) {
         console.warn(
           "Using a component in findComponent is deprecated. " +
           "Pass name and props as separate arguments instead"
@@ -280,13 +277,4 @@ function mapcat(array, fn) {
     result.push.apply(result, fn(x, i));
   });
   return result;
-}
-
-function clone(obj) {
-  if (null == obj || "object" != typeof obj) return obj;
-  var copy = obj.constructor();
-  for (var attr in obj) {
-    if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
-  }
-  return copy;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,9 +2,10 @@ var chai = require('chai');
 var expect = chai.expect;
 
 var React = require('react');
-var versionNumber = Number(React.version.substring(0, 4));
-var TestUtils;
-if (versionNumber>=0.13) {
+var React013 = (React.version.substring(0, 4) == '0.13');
+
+var createFragment;
+if (React013) {
   createFragment = require('react/addons').addons.createFragment;
 } else {
   createFragment = require('react-addons-create-fragment');

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@ var expect = chai.expect;
 
 var React = require('react');
 var versionNumber = Number(React.version.substring(0, 4));
-console.log('version number ...............', versionNumber);
 var TestUtils;
 if (versionNumber>=0.13) {
   createFragment = require('react/addons').addons.createFragment;
@@ -605,6 +604,115 @@ describe("skin-deep", function() {
         expect(c).to.have.property('type', Widget);
         expect(c.props).to.eql({ some: "value", num: 123 });
         expect(warning).to.match(/deprecated/);
+      });
+    });
+  });
+
+  describe("findComponentsWithoutChildren", function() {
+    var Widget = React.createClass({
+      displayName: 'Widget',
+      render: function() {}
+    });
+    var tree = sd.shallowRender(
+      $('div', {},
+        $('span', {}, "stuff", "and", "nonsense"),
+        $('span', {}, "stuff", "and", "nonsense"),
+        $('b', { className: "go"}, "away"),
+        $('b', { className: "go"}, "away"),
+        $(Widget, { some: "value", num: 123 }),
+        $(Widget, { some: "value", num: 123 }),
+        $(Widget, {}, "kids"),
+        $(Widget, {}, "kids")
+      )
+    );
+    it("should find DOM components ccccccc", function() {
+      var c = tree.findComponentsWithoutChildren('span', {});
+      expect(c).to.have.length(2);
+      c.forEach( function(i) {
+        expect(i).to.have.property('type', 'span');
+        expect(i.props.children).to.eql(["stuff", "and", "nonsense"]);
+      });
+    });
+    it("should find DOM components with props", function() {
+      var c = tree.findComponentsWithoutChildren('b', { className: "go" });
+      expect(c).to.have.length(2);
+      c.forEach( function(i) {
+        expect(i).to.have.property('type', 'b');
+        expect(i.props).to.eql({ className: "go", children: "away" });
+      });
+    });
+    it("should find components",   function() {
+      var c = tree.findComponentsWithoutChildren('Widget', {});
+      expect(c).to.have.length(2);
+      c.forEach(function(i) {
+        expect(i).to.have.property('type', Widget);
+        expect(i.props).to.eql({ children: "kids" });
+      });
+    });
+    it("should find components with props", function() {
+      var c = tree.findComponentsWithoutChildren('Widget', { some: "value", num: 123 });
+      expect(c).to.have.length(2);
+      c.forEach(function(i) {
+        expect(i).to.have.property('type', Widget);
+        expect(i.props).to.eql({ some: "value", num: 123 });
+      });
+    });
+    it("should find components disregarding children in query", function() {
+      var c = tree.findComponentsWithoutChildren('Widget', { children: "not kids" });
+      expect(c).to.have.length(2);
+      c.forEach(function(i) {
+        expect(i).to.have.property('type', Widget);
+        expect(i.props).to.eql({ children: "kids" });
+      });
+    });
+    it("should fail to find components", function() {
+      expect(tree.findComponentsWithoutChildren('Widget', { "other": "value"}))
+        .to.have.length(0);
+    });
+    describe("back-compat with a warning", function() {
+      var originalWarn = console.warn;
+      var warning;
+      beforeEach(function() {
+        warning = null;
+        console.warn = function(msg) { warning = msg; };
+      });
+      afterEach(function() {
+        console.warn = originalWarn;
+      });
+      it("should find DOM components", function() {
+        var c = tree.findComponentsWithoutChildren($('span', {}, "stuff", "and", "nonsense"));
+        expect(c).to.have.length(2);
+        c.forEach(function(i) {
+          expect(i).to.have.property('type', 'span');
+          expect(warning).to.match(/deprecated/);
+        });
+      });
+      it("should find DOM components with props", function() {
+        var c = tree.findComponentsWithoutChildren($('b', { className: "go" }, "away"));
+        expect(c).to.have.length(2);
+        c.forEach(function(i) {
+          expect(i).to.have.property('type', 'b');
+          expect(i.props).to.eql({ className: "go", children: "away" });
+          expect(warning).to.match(/deprecated/);
+        });
+      });
+      it("should find components", function() {
+        var c = tree.findComponentsWithoutChildren($(Widget, {}));
+        expect(c).to.have.length(2);
+        c.forEach(function(i) {
+          expect(i).to.have.property('type', Widget);
+          expect(i.props).to.eql({ children: 'kids' });
+          expect(warning).to.match(/deprecated/);
+        });
+      });
+      it("should find components with props", function() {
+        var c = tree.findComponentsWithoutChildren($(Widget, { some: "value", num: 123 }));
+        expect(c).to.have.length(2);
+        c.forEach(function(i) {
+          expect(i).to.have.property('type', Widget);
+          expect(i.props).to.eql({ some: "value", num: 123 });
+          expect(warning).to.match(/deprecated/);
+        });
       });
     });
   });


### PR DESCRIPTION
For shallow rendering sometimes we just want to find the components with the exact matching props without regard to its children. Consider the following example:
```
<Dropzone onDrop={this.onDrop} supportClick={true} className="bgp-attachment-dropzone" inputId={this.elementId('input')} multiple={true}>
              <div className="bgp-dropzone-instruction">
                Drag and drop files here
              </div>
</Dropzone>
```
In this case, we are not concerned whether its child is 
```
<div className="bgp-dropzone-instruction">
                Drag and drop files here
              </div>
```

I have implemented findComponentsWithoutChildren and findComponentsWithoutChildren to facilitate such testing.
