### PR TITLE
set displayName as fallthrough case for createNodePredicate function.

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -172,10 +172,8 @@ function createNodePredicate(query) {
   if (query.match(/^[a-z][\w\-]*$/)) { // tagname
     return function(n) { return n.type == query; };
   }
-  if (query.match(/^[A-Z][\w\-]*$/)) { // component displayName
-    return function(n) { return n.type && getComponentName(n.type) == query; };
-  }
-  throw new Error('Invalid node query ' + query);
+  // component displayName
+  return function(n) { return n.type && getComponentName(n.type) == query; };  
 }
 
 function findNodeIn(node, query) {

--- a/test/test.js
+++ b/test/test.js
@@ -204,12 +204,6 @@ describe("skin-deep", function() {
       expect(tree.findNode("#abc")).to.eql(false);
     });
 
-    it("should throw on invalid selector", function() {
-      expect(function() {
-        tree.findNode(";huh?");
-      }).to.throw(/invalid/i);
-    });
-
     describe("conditionals", function() {
       before(function() {
         tree = sd.shallowRender(

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,11 @@ describe("skin-deep", function() {
       displayName: 'Widget',
       render: function() { return 'widget'; }
     });
+
+    var ReduxWidget = React.createClass({
+      displayName: 'Connect(Widget)',
+      render: function() { return 'redux-widget'; }
+    });
     function Widget2() {}
     Widget2.prototype = Object.create(React.Component);
     Widget2.prototype.render = function() { return 'widget'; };
@@ -166,7 +171,8 @@ describe("skin-deep", function() {
           'hello',
           [$('div', {className: "abc", key: "1"}, "ABC")],
           $(Widget, {}),
-          $(Widget2, {})
+          $(Widget2, {}),
+          $(ReduxWidget, {})
         )
       )
     );
@@ -192,6 +198,9 @@ describe("skin-deep", function() {
     it("should find a node in tree by component displayName", function() {
       var abc = tree.findNode("Widget");
       expect(abc).to.have.property('type', Widget);
+
+      var xyz = tree.findNode("Connect(Widget)");
+      expect(xyz).to.have.property('type', ReduxWidget);
     });
 
     it("should find a node in tree by component class name", function() {


### PR DESCRIPTION
Based on issue #18, removing query match for component displayName and using that as the fallthrough case instead of throwing an invalid node query error.