### PR TITLE
Add [attr] and [attr="val"] to findNode capabilities

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -2,6 +2,7 @@ var subset = require('is-subset');
 
 var React = require('react');
 var React013 = (React.version.substring(0, 4) == '0.13');
+var ATTR_REGEX = /^[\[]([a-z0-9\-]+)([=]["]([a-z0-9\-]+)["])?[\]]$/;
 
 var TestUtils;
 if (React013) {
@@ -172,8 +173,11 @@ function createNodePredicate(query) {
   if (query.match(/^[a-z][\w\-]*$/)) { // tagname
     return function(n) { return n.type == query; };
   }
+  if (query.match(ATTR_REGEX)) { // [attr="val"]
+    return findNodeByAttrWithValue(query);
+  }
   // component displayName
-  return function(n) { return n.type && getComponentName(n.type) == query; };  
+  return function(n) { return n.type && getComponentName(n.type) == query; };
 }
 
 function findNodeIn(node, query) {
@@ -186,6 +190,19 @@ function findNodeByClass(cls) {
   return function(n) {
     return n.props && String(n.props.className).match(regex);
   };
+}
+
+function findNodeByAttrWithValue(query) {
+  var groups = ATTR_REGEX.exec(query);
+  var attr = groups[1];
+  var value = groups[3];
+  return (value || value === "")
+    ? function(n) {
+        return n.props && String(n.props[attr]) === value;
+      }
+    : function(n) {
+        return n.props && attr in n.props;
+      };
 }
 
 function findNodeById(id) {

--- a/test/test.js
+++ b/test/test.js
@@ -169,7 +169,7 @@ describe("skin-deep", function() {
           $('div', {}, "objection!"),
           $('object', {}, "objection!"),
           'hello',
-          [$('div', {className: "abc", key: "1"}, "ABC")],
+          [$('div', {className: "abc", key: "1", "data-attr": "yay"}, "ABC")],
           $(Widget, {}),
           $(Widget2, {}),
           $(ReduxWidget, {})
@@ -179,6 +179,18 @@ describe("skin-deep", function() {
 
     it("should find a node in tree by className", function() {
       var abc = tree.findNode(".abc");
+      expect(abc).to.have.property('type', 'div');
+      expect(abc.props).to.have.property('children', 'ABC');
+    });
+
+    it("should find a node in tree by attr only", function() {
+      var abc = tree.findNode("[data-attr]");
+      expect(abc).to.have.property('type', 'div');
+      expect(abc.props).to.have.property('children', 'ABC');
+    });
+
+    it("should find a node in tree by attr & value", function() {
+      var abc = tree.findNode("[data-attr=\"yay\"]");
       expect(abc).to.have.property('type', 'div');
       expect(abc.props).to.have.property('children', 'ABC');
     });

--- a/test/test.js
+++ b/test/test.js
@@ -195,6 +195,10 @@ describe("skin-deep", function() {
       expect(abc.props).to.have.property('children', 'ABC');
     });
 
+    it("should not find a node in tree by attr & unmatched value", function() {
+      expect(tree.findNode("[data-attr=\"boo\"]")).to.eql(false);
+    });
+
     it("should find a node in tree by id", function() {
       var abc = tree.findNode("#def");
       expect(abc).to.have.property('type', 'div');


### PR DESCRIPTION
Added support for `tree.findNode('[data-has-tests="yay"]')`. Tests added and passing.