### PR TITLE
Implement findNodes()

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -111,6 +111,9 @@ function SkinDeep(getCurrentNode, renderer, instance) {
     findNode: function(query) {
       return findNode(getCurrentNode(), createNodePredicate(query));
     },
+    findNodes: function(query) {
+      return findNodes(getCurrentNode(), createNodePredicate(query));
+    },
     textIn: function(query) {
       var node = findNode(getCurrentNode(), createNodePredicate(query));
       return getTextFromNode(node);

--- a/test/test.js
+++ b/test/test.js
@@ -258,6 +258,29 @@ describe("skin-deep", function() {
     });
   });
 
+  describe("findNodes", function() {
+    var Widget = React.createClass({
+      displayName: 'Widget',
+      render: function() { return 'widget'; }
+    });
+
+    var tree = sd.shallowRender(
+      $('div', {},
+        $(Widget, {}),
+        $(Widget, {})
+      )
+    );
+
+    it("should find two nodes in tree by component displayName", function() {
+      var widgets = tree.findNodes("Widget");
+      expect(widgets).to.be.an('array');
+      expect(widgets).to.have.length(2);
+      expect(widgets[0]).to.have.property('type', Widget);
+      expect(widgets[1]).to.have.property('type', Widget);
+    });
+
+  });
+
   describe("textIn", function() {
     var tree = sd.shallowRender(
       $('div', {},


### PR DESCRIPTION
`findNode()` is awesome! But sometimes you want to query multiple nodes.

This PR implements `findNodes()` which does exact the same as `findNode()` but returns an array.