### PR TITLE
Class tester should test for whitespace surrounding the className

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -220,7 +220,7 @@ function createFinder(selector, predicate, isLike) {
 }
 
 function findNodeByClass(cls) {
-  var regex = new RegExp('\\b' + cls + '\\b');
+  var regex = new RegExp('\\s' + cls + '\\s');
 
   return function(n) {
     return n.props && String(n.props.className).match(regex);


### PR DESCRIPTION
Using only word boundaries surrounding the className, we get false positives. Eg. for a node with class 'not-active',  findNode('.not-active') returns true but findNode('active') returns true as well.