### PR TITLE
Move some devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
   },
   "homepage": "https://github.com/glenjamin/skin-deep",
   "dependencies": {
-    "is-subset": "^0.1.1"
+    "is-subset": "^0.1.1",
+    "react": "^0.14.0",
+    "react-addons-create-fragment": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "chai": "^3.4.0",
     "coveralls": "^2.11.2",
     "eslint": "^1.10.3",
     "istanbul": "^0.4.0",
-    "mocha": "^2.2.5",
-    "react": "^0.14.0",
-    "react-addons-create-fragment": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "mocha": "^2.2.5"
   }
 }


### PR DESCRIPTION
I admit, not having `react`, or `react-dom` installed when using skin deep is a weird scenario... But I did not used the `react-addons-test-utils` before and my tested failed after adding and using skin deep: `Error: Cannot find module 'react-addons-test-utils'`.

It's quite handy that you abstract the boilerplate away but I think you should then also list it as a dependency so users don't need to install it manually right? 

Thanks anyway, works like a charm!