### PR TITLE
Partial support to get by refs

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -299,7 +299,6 @@ function getCurrentNodeRef(node, ref) {
   // Falsy stuff can't match or have children
   if (!node) return false;
 
-  // Array nodes all get checked
   if (Array.isArray(node)) {
     var result = findRefAmongArrayEntries(node, ref)
     if (result) return result
@@ -309,12 +308,6 @@ function getCurrentNodeRef(node, ref) {
     return node;
   }
 
-  /*
-   * Unfortunately, I didn't find a way to consider the refs
-   * passed as children to a childReactComponent. Only direct
-   * children of the root of the tree and the subsequent children of DOM
-   * element only will be considered
-   */
   if (!isAReactComponent(node)) {
     return findRefAmongChildren(node, ref)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,58 @@ var $ = React.createElement;
 
 describe("skin-deep", function() {
 
+  describe('getCurrentNodeRef', function() {
+    var aReactComponentChildRef = 'childrenRef';
+    var aDOMElementChildRef = 'childrenRef2';
+    var aRootRef = 'rootRef';
+    var anUnexistingRef = 'aSillyRef';
+
+    var ComponentWithChildrenRefs = React.createClass({
+      render: function() {
+        return $('h1', { ref: aReactComponentChildRef }, this.context.title);
+      }
+    });
+
+    var RootComponent = React.createClass({
+      render: function() {
+        return $('div', {},
+                 $(ComponentWithChildrenRefs),
+                 $('div', {ref: aRootRef},
+                   $('div', {ref: aDOMElementChildRef})
+                  )
+                );
+      }
+    });
+
+    it('should return false if the root does not have any element with the\
+       given ref', function() {
+      var tree = sd.shallowRender($(RootComponent));
+      var result = tree.getRootRef(anUnexistingRef);
+      expect(result).to.be.false;
+    });
+
+    it('should return the subtree of the requested ref at immediate\
+       level', function() {
+      var tree = sd.shallowRender($(RootComponent));
+      var result = tree.getRootRef(aRootRef);
+      expect(result.ref).to.be.equal(aRootRef);
+    });
+
+    it('should return the subtree of the requested ref even at\
+       DOM-nested-level', function() {
+      var tree = sd.shallowRender($(RootComponent));
+      var result = tree.getRootRef(aDOMElementChildRef);
+      expect(result.ref).to.be.equal(aDOMElementChildRef);
+    });
+
+    it('should not return the ref of the root react component children even if\
+       they match the requested value', function() {
+      var tree = sd.shallowRender($(RootComponent));
+      var result = tree.getRootRef(aReactComponentChildRef);
+      expect(result).to.be.false;
+    });
+  })
+
   describe("getRenderOutput", function() {
 
     it("should render a ReactElement", function() {


### PR DESCRIPTION
Ok so for testing purposes I find it more robust to get my functional elements using refs instead of using:
* classes (subject to be messed with when styling),
* id (has to be unique project-wide),
* props (no consistent way),
* etc. (open to better suggestion though :) )

I use some functional/integration on top of unit tests.

Unfortunately, shallowRender doesn't support refs but with the nodes use by `skin-deep` it's possible to at least compare `node.ref`.

The "partial support" come from the fact that the ref `Root.refs.A` on an element B wont be found by
```javascript
var tree = sd.shallowRender($(Root));
tree.getRootRef(A);
```
if B is passed to a children (of the Root component) React component C as a children of the latter. Example:
```javascript
class Root extends React.Component {
  render() {
    return (
      <C>
        <B ref='A' />
      </C>
    )
 }
}
```
I make this pull request in case this can be seen as useful for someone and maybe someone can find some clever way to make it better (Or just some better name for the function... I find it pretty hard to get a descriptive name).

What do you think ?