### PR TITLE
Fix dive altering input variable

### DIFF
--- a/skin-deep.js
+++ b/skin-deep.js
@@ -68,13 +68,12 @@ function SkinDeep(getCurrentNode, renderer, instance) {
     },
     dive: function(paths, context) {
       var tree = api;
-      while (paths.length) {
-        var path = paths.shift();
+      paths.forEach(function(path) {
         var rawTree = tree.subTree(path);
         if (!rawTree) throw new Error(path + ' not found in tree');
         var node = rawTree.getRenderOutput();
         tree = shallowRender(node, context);
-      }
+      });
       return tree;
     },
     text: function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1124,5 +1124,13 @@ describe("skin-deep", function() {
         return greatTree.dive(['Granny', 'Mum', 'h4'], { name: 'Jane' });
       }).to.throw('h4 not found in tree');
     });
+    it('should not alter the input path variable', function() {
+      var path = ['Granny', 'Mum'];
+      var result = greatTree.dive(path, { name: 'Jane' });
+      expect(result.getRenderOutput().props.contextName).to.eql('Jane');
+
+      var result2 = greatTree.dive(path, { name: 'Jane' });
+      expect(result2.getRenderOutput().props.contextName).to.eql('Jane');
+    });
   });
 });


### PR DESCRIPTION
Hi Glen,
Discovered that dive was altering the input variable by calling `shift`.  Not sure why using a `while` and `shift`, so switched to `forEach`.  Guess other way would be to take a copy of the array if you don't like the `forEach`...