### PR TITLE
Add support for React 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ env:
   - REACT=15.4
   - REACT=15.5
   - REACT=15.6
+  - REACT=16.0
 before_script: "sh install-relevant-react.sh"

--- a/install-relevant-react.sh
+++ b/install-relevant-react.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-REACT=${REACT:-15.6}
+REACT=${REACT:-16.0}
 
 echo "installing React $REACT"
 
@@ -8,12 +8,14 @@ npm prune
 
 npm install react@$REACT \
     react-dom@$REACT \
-    react-addons-test-utils@$REACT \
-    react-addons-create-fragment@$REACT \
     @types/react
 
-if node_modules/.bin/semver -r '>= 15.5' "$REACT.0"; then
-    npm install create-react-class@$REACT \
+if node_modules/.bin/semver -r '>= 15.5.0' "$REACT.0"; then
+    npm install create-react-class@15 \
         prop-types@15 \
-        react-test-renderer@15
+        react-addons-create-fragment@15 \
+        react-test-renderer@$REACT
+else
+    npm install react-addons-test-utils@$REACT \
+        react-addons-create-fragment@$REACT
 fi

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -2,3 +2,4 @@ var React = require('react');
 var semver = require('semver');
 
 exports.ReactBefore155 = semver.lt(React.version, "15.5.0");
+exports.ReactBefore16 = semver.lt(React.version, "16.0.0");

--- a/skin-deep.js
+++ b/skin-deep.js
@@ -8,6 +8,8 @@ var ReactElementToString = require('react-element-to-string');
 
 var traversal = require('./lib/traversal');
 
+var Versions = require('./lib/versions');
+
 var ReactCompat = require('./lib/react-compat');
 
 var TestUtils = ReactCompat.TestUtils;
@@ -37,7 +39,9 @@ function shallowRender(element, context) {
     },
     shallowRenderer,
     /* eslint-disable no-underscore-dangle */
-    shallowRenderer._instance._instance
+    Versions.ReactBefore16
+      ? shallowRenderer._instance._instance
+      : shallowRenderer._instance
     /* eslint-enable no-underscore-dangle */
   );
 }


### PR DESCRIPTION
This updates the tests to use React 16 and demonstrates the issue described in #93.

```
$ mocha
/Users/philipp/dev/skin-deep/skin-deep.js:40
    shallowRenderer._instance._instance
                             ^

TypeError: Cannot read property '_instance' of null
    at Object.shallowRender (/Users/philipp/dev/skin-deep/skin-deep.js:40:30)
    at Suite.<anonymous> (/Users/philipp/dev/skin-deep/test/new.js:75:21)
    at context.describe.context.context (/Users/philipp/dev/skin-deep/node_modules/mocha/lib/interfaces/bdd.js:47:10)
    at Suite.<anonymous> (/Users/philipp/dev/skin-deep/test/new.js:71:5)
    at context.describe.context.context (/Users/philipp/dev/skin-deep/node_modules/mocha/lib/interfaces/bdd.js:47:10)
    at Suite.<anonymous> (/Users/philipp/dev/skin-deep/test/new.js:32:3)
    at context.describe.context.context (/Users/philipp/dev/skin-deep/node_modules/mocha/lib/interfaces/bdd.js:47:10)
    at Object.<anonymous> (/Users/philipp/dev/skin-deep/test/new.js:27:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at /Users/philipp/dev/skin-deep/node_modules/mocha/lib/mocha.js:220:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/philipp/dev/skin-deep/node_modules/mocha/lib/mocha.js:217:14)
    at Mocha.run (/Users/philipp/dev/skin-deep/node_modules/mocha/lib/mocha.js:469:10)
    at Object.<anonymous> (/Users/philipp/dev/skin-deep/node_modules/mocha/bin/_mocha:404:18)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```